### PR TITLE
settings needs to be object to use extend()

### DIFF
--- a/js/tablecellsselection.js
+++ b/js/tablecellsselection.js
@@ -2,7 +2,7 @@
 
 (function($, window, document, undefined) {
 
-    var settings;
+    var settings = {};
     
     var systemSettings = {
         dataKey : 'cellsSelector',


### PR DESCRIPTION
If settings was not an object there was an error on save and the content of CKEditor was not saved.
